### PR TITLE
Fix CHRSTATUS

### DIFF
--- a/src/Palazzetti.cpp
+++ b/src/Palazzetti.cpp
@@ -2137,7 +2137,7 @@ Palazzetti::CommandResult Palazzetti::getChronoData(byte *CHRSTATUS, float (*PCH
         return cmdRes;
 
     if (CHRSTATUS)
-        *CHRSTATUS = chronoDataStatus & 0x01;
+        *CHRSTATUS = _CHRSTATUS; // original code should have been "chronoDataStatus > 0 ? 1 : 0" but _CHRSTATUS is readily available...
     for (byte i = 0; i < 6; i++)
     {
         if (PCHRSETP)

--- a/src/Palazzetti.cpp
+++ b/src/Palazzetti.cpp
@@ -2137,7 +2137,7 @@ Palazzetti::CommandResult Palazzetti::getChronoData(byte *CHRSTATUS, float (*PCH
         return cmdRes;
 
     if (CHRSTATUS)
-        *CHRSTATUS = chronoDataStatus;
+        *CHRSTATUS = chronoDataStatus & 0x01;
     for (byte i = 0; i < 6; i++)
     {
         if (PCHRSETP)


### PR DESCRIPTION
Missed one odd/even calculation, I think.

```
curl "http://IP/cgi-bin/sendmsg.lua?cmd=GET+CHRD"
{"INFO":{"CMD":"GET CHRD","RSP":"OK","TS":1732559000}},"DATA":{"CHRSTATUS":116,"Programs":{"P1"...

```

```
curl "http://IP/cgi-bin/sendmsg.lua?cmd=GET+ALLS"
{"INFO":{"CMD":"GET ALLS","RSP":"OK","TS":1732559104}},"DATA":{...,"CHRSTATUS":0,"...  
```

```
curl "http://IP/cgi-bin/sendmsg.lua?cmd=EXT+ADRD+207E+0"
{"INFO":{"CMD":"EXT ADRD 207E 0","RSP":"OK","TS":1732559204},"DATA":{"DATATYPE":"BYTE","ADDR_207E":116},"SUCCESS":true}% 
```

Raw value is 116, but result is supposed to be a bool (odd/even)